### PR TITLE
Thuong/patch cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,5 @@ REDIS_PORT=6379
 
 # Server Configuration
 SERVER_PORT=8080
+
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,7 @@ application-local.properties
 application-dev.properties
 application-prod.properties
 
+compose.test.yml
+
 # Ignore file properties in the root directory
 *.properties

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -1,19 +1,36 @@
-### Building and running your application
+### Running with Docker
 
-When you're ready, start your application by running:
-`docker compose up --build`.
+In order to run the api image without any errors, you need to provide the following environment variables:
 
-Your application will be available at http://localhost:8080.
-
-### Deploying your application to the cloud
-
-First, build your image, e.g.: `docker build -t myapp .`.
-If your cloud uses a different CPU architecture than your development
-machine (e.g., you are on a Mac M1 and your cloud provider is amd64),
-you'll want to build the image for that platform, e.g.:
-`docker build --platform=linux/amd64 -t myapp .`.
-
-Then, push it to your registry, e.g. `docker push myregistry.com/myapp`.
-
-Consult Docker's [getting started](https://docs.docker.com/go/get-started-sharing/)
-docs for more detail on building and pushing.
+```yml
+  environment:
+    - "DB_URL=jdbc:mysql://localhost:3306/busify?createDatabaseIfNotExist=true"
+    - "DB_USER=root"
+    - "DB_PASSWORD=1111"
+    - "MONGO_URI=mongodb://localhost:27017/busify"
+    - "MONGO_DATABASE=busify"
+    - "JWT_SECRET="
+    - "JWT_EXPIRATION=86400000"
+    - "JWT_REFRESH_EXPIRATION=604800000"
+    - "PAYPAL_CLIENT_ID="
+    - "PAYPAL_CLIENT_SECRET="
+    - "PAYPAL_MODE=sandbox"
+    - "VNPAY_MERCHANT_CODE="
+    - "VNPAY_SECRET_KEY="
+    - "VNPAY_URL=https://sandbox.vnpayment.vn/paymentv2/vpcpay.html"
+    - "VNPAY_REFUND_URL=https://sandbox.vnpayment.vn/merchant_webapi/api/transaction"
+    - "VNPAY_RETURN_URL=http://localhost:3000/payment/callback"
+    - "GOOGLE_CLIENT_ID="
+    - "GOOGLE_CLIENT_SECRET="
+    - "GOOGLE_REDIRECT_URI=http://localhost:8080/login/oauth2/code/google"
+    - "MAIL_USERNAME="
+    - "MAIL_PASSWORD="
+    - "FRONTEND_URL=http://localhost:3000"
+    - "CLOUDINARY_CLOUD_NAME="
+    - "CLOUDINARY_API_KEY="
+    - "CLOUDINARY_API_SECRET="
+    - "REDIS_HOST=localhost"
+    - "REDIS_PORT=6379"
+    - "SERVER_PORT=8080"
+    - "OPENAI_API_KEY="
+```

--- a/compose.yaml
+++ b/compose.yaml
@@ -31,6 +31,8 @@ services:
     environment:
       - PMA_HOST=mysql
       - PMA_PORT=3306
+      # - PMA_HOST=server.aptech.io:3307
+      # - PMA_PORT=3307
     depends_on:
       - mysql
   mongo:

--- a/src/main/java/com/busify/project/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/busify/project/user/service/impl/UserServiceImpl.java
@@ -78,11 +78,10 @@ public class UserServiceImpl implements UserService {
         }
         return UserMapper.toDTO((Profile) user);
     }
-    
+
     @Caching(evict = {
-        @CacheEvict(value = "userById", key = "#id"),
-        @CacheEvict(value = "userProfile", key = "'current_user'"),
-        @CacheEvict(value = "allUsers", allEntries = true)
+            @CacheEvict(value = "userById", key = "#id"),
+            @CacheEvict(value = "allUsers", allEntries = true)
     })
     @Override
     public UserDTO updateUserProfile(Long id, UserDTO userDTO) {
@@ -120,10 +119,15 @@ public class UserServiceImpl implements UserService {
         if (!(user instanceof Profile)) {
             throw new RuntimeException("User is not a Profile with email: " + email);
         }
-        return getUserById(user.getId());
+        return cacheUserProfile(user.getId(), (Profile) user);
     }
 
-    @CacheEvict(value = {"userById", "userProfile", "allUsers"}, allEntries = true)
+    @Cacheable(value = "userById", key = "#id")
+    public UserDTO cacheUserProfile(Long id, Profile profile) {
+        return UserMapper.toDTO(profile);
+    }
+
+    @CacheEvict(value = { "userById", "userProfile", "allUsers" }, allEntries = true)
     @Override
     public void changePassword(ChangePasswordRequestDTO request) {
         // Lấy email user đang đăng nhập
@@ -241,9 +245,8 @@ public class UserServiceImpl implements UserService {
     }
 
     @Caching(evict = {
-        @CacheEvict(value = "userById", key = "#id"),
-        @CacheEvict(value = "userProfile", key = "'current_user'"),
-        @CacheEvict(value = "allUsers", allEntries = true)
+            @CacheEvict(value = "userById", key = "#id"),
+            @CacheEvict(value = "allUsers", allEntries = true)
     })
     @Override
     public void deleteUserById(Long id) {

--- a/src/main/java/com/busify/project/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/busify/project/user/service/impl/UserServiceImpl.java
@@ -124,7 +124,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Cacheable(value = "userProfile", key = "#id")
-    public UserDTO cacheUserProfile(Long id, Profile profile) {
+    UserDTO cacheUserProfile(Long id, Profile profile) {
         return UserMapper.toDTO(profile);
     }
 

--- a/src/main/java/com/busify/project/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/busify/project/user/service/impl/UserServiceImpl.java
@@ -81,6 +81,7 @@ public class UserServiceImpl implements UserService {
 
     @Caching(evict = {
             @CacheEvict(value = "userById", key = "#id"),
+            @CacheEvict(value = "userProfile", key = "#id"),
             @CacheEvict(value = "allUsers", allEntries = true)
     })
     @Override
@@ -122,7 +123,7 @@ public class UserServiceImpl implements UserService {
         return cacheUserProfile(user.getId(), (Profile) user);
     }
 
-    @Cacheable(value = "userById", key = "#id")
+    @Cacheable(value = "userProfile", key = "#id")
     public UserDTO cacheUserProfile(Long id, Profile profile) {
         return UserMapper.toDTO(profile);
     }
@@ -246,6 +247,7 @@ public class UserServiceImpl implements UserService {
 
     @Caching(evict = {
             @CacheEvict(value = "userById", key = "#id"),
+            @CacheEvict(value = "userProfile", key = "#id"),
             @CacheEvict(value = "allUsers", allEntries = true)
     })
     @Override

--- a/src/main/java/com/busify/project/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/busify/project/user/service/impl/UserServiceImpl.java
@@ -112,7 +112,6 @@ public class UserServiceImpl implements UserService {
         return UserMapper.toDTO(profile);
     }
 
-    @Cacheable(value = "userProfile", key = "'current_user'")
     @Override
     public UserDTO getUserProfile() {
         String email = utils.getCurrentUserLogin().isPresent() ? utils.getCurrentUserLogin().get() : "";
@@ -121,7 +120,7 @@ public class UserServiceImpl implements UserService {
         if (!(user instanceof Profile)) {
             throw new RuntimeException("User is not a Profile with email: " + email);
         }
-        return UserMapper.toDTO((Profile) user);
+        return getUserById(user.getId());
     }
 
     @CacheEvict(value = {"userById", "userProfile", "allUsers"}, allEntries = true)


### PR DESCRIPTION
This pull request updates the environment variable documentation for Docker, refines environment variable handling, and refactors user profile caching in the `UserServiceImpl` class. The main focus is on improving configuration clarity and optimizing caching logic for user profiles.

**Environment variable and Docker configuration improvements:**

* Updated `README.Docker.md` to provide explicit instructions for setting all required environment variables when running with Docker, including the addition of `OPENAI_API_KEY` and other service credentials.
* Added `OPENAI_API_KEY` to the `.env.example` file to clarify required environment variables.
* Added commented-out alternative host/port examples for phpMyAdmin in `compose.yaml` to improve clarity for database configuration.

**User profile caching refactor:**

* Removed the `@Cacheable` annotation from the `getUserProfile` method and introduced a new `cacheUserProfile` method, which is now responsible for caching user profile DTOs by user ID, improving cache granularity and consistency. [[1]](diffhunk://#diff-7a85739575f975fc3e1c2d1d2eea56ed8aa20690b732a78e0be675e8e47580a7L115) [[2]](diffhunk://#diff-7a85739575f975fc3e1c2d1d2eea56ed8aa20690b732a78e0be675e8e47580a7L124-R127)
* Updated cache eviction annotations in `updateUserById` and `getUserById` to remove unnecessary eviction of the `userProfile` cache, aligning with the new caching strategy. [[1]](diffhunk://#diff-7a85739575f975fc3e1c2d1d2eea56ed8aa20690b732a78e0be675e8e47580a7L84) [[2]](diffhunk://#diff-7a85739575f975fc3e1c2d1d2eea56ed8aa20690b732a78e0be675e8e47580a7L246)